### PR TITLE
Fix zrange error

### DIFF
--- a/aredis/commands/sorted_set.py
+++ b/aredis/commands/sorted_set.py
@@ -155,8 +155,8 @@ class SortedSetCommandMixin:
         ``score_cast_func`` a callable used to cast the score return value
         """
         if desc:
-            return self.zrevrange(name, start, end, withscores,
-                                  score_cast_func)
+            return await self.zrevrange(name, start, end, withscores,
+                                        score_cast_func)
         pieces = ['ZRANGE', name, start, end]
         if withscores:
             pieces.append(b('WITHSCORES'))


### PR DESCRIPTION
When using "zrange" with "desc=True" parameter, it returns a coroutine without "await".

## Description

Please describe your pull request.

NOTE: All patches should be made against master!

If it fixes a bug or resolves a feature request be sure to link to that issue.
It is appreciated if you can make an issue before making a pull request.